### PR TITLE
switch to using the catch2 cmake sharding interface

### DIFF
--- a/Code/GraphMol/DistGeomHelpers/CMakeLists.txt
+++ b/Code/GraphMol/DistGeomHelpers/CMakeLists.txt
@@ -9,18 +9,13 @@ rdkit_headers(BoundsMatrixBuilder.h
 
 rdkit_catch_test(testDistGeomHelpers testDgeomHelpers.cpp
            LINK_LIBRARIES
-           DistGeomHelpers MolTransforms FileParsers SmilesParse  )
+           DistGeomHelpers MolTransforms FileParsers SmilesParse SHARD_COUNT 4 )
 
 rdkit_catch_test(distGeomHelpersCatch catch_tests.cpp 
-LINK_LIBRARIES DistGeomHelpers MolTransforms FileParsers SmilesParse )
+LINK_LIBRARIES DistGeomHelpers MolTransforms FileParsers SmilesParse SHARD_COUNT 4 )
 
-rdkit_catch_test(testDgeomHelpersGH3019_0 testGithub3019.cpp
-           LINK_LIBRARIES DistGeomHelpers SmilesParse
-           CLIARGS --shard-count=2 --shard-index=0 )
-
-rdkit_catch_test(testDgeomHelpersGH3019_1 testGithub3019.cpp
-           LINK_LIBRARIES DistGeomHelpers SmilesParse 
-           CLIARGS --shard-count=2 --shard-index=1 )
+rdkit_catch_test(testDgeomHelpersGH3019 testGithub3019.cpp
+           LINK_LIBRARIES DistGeomHelpers SmilesParse SHARD_COUNT 2)
 
 
 if(RDK_BUILD_PYTHON_WRAPPERS)

--- a/Code/cmake/Modules/RDKitUtils.cmake
+++ b/Code/cmake/Modules/RDKitUtils.cmake
@@ -1,3 +1,5 @@
+include(CatchShardTests)
+
 include(BoostUtils)
 IF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 # Mac OS X specific code
@@ -231,7 +233,7 @@ endmacro(rdkit_test)
 
 macro(rdkit_catch_test)
   PARSE_ARGUMENTS(RDKTEST
-    "LINK_LIBRARIES;DEPENDS;DEST;CLIARGS"
+    "LINK_LIBRARIES;DEPENDS;DEST;CLIARGS;SHARD_COUNT"
     ""
     ${ARGN})
   CAR(RDKTEST_NAME ${RDKTEST_DEFAULT_ARGS})
@@ -239,7 +241,11 @@ macro(rdkit_catch_test)
   if(RDK_BUILD_CPP_TESTS)
     add_executable(${RDKTEST_NAME} ${RDKTEST_SOURCES})
     target_link_libraries(${RDKTEST_NAME} PRIVATE rdkitCatch ${RDKTEST_LINK_LIBRARIES} Catch2::Catch2)
-    add_test(${RDKTEST_NAME} ${EXECUTABLE_OUTPUT_PATH}/${RDKTEST_NAME} ${RDKTEST_CLIARGS})
+    if(${RDKTEST_SHARD_COUNT})
+      catch_add_sharded_tests(${RDKTEST_NAME} SHARD_COUNT ${RDKTEST_SHARD_COUNT})
+    else()
+      add_test(${RDKTEST_NAME} ${EXECUTABLE_OUTPUT_PATH}/${RDKTEST_NAME} ${RDKTEST_CLIARGS})
+    endif()
   endif(RDK_BUILD_CPP_TESTS)
 endmacro(rdkit_catch_test)
 


### PR DESCRIPTION
It seems like the catch2 + cmake sharding interface you discovered makes this a bit easier *and* allows us to easily shard other long-running tests.

How about doing it this way instead?